### PR TITLE
feat(tools): 集成 You.com 联网搜索工具

### DIFF
--- a/src/main/resources/application-prod-sample.yml
+++ b/src/main/resources/application-prod-sample.yml
@@ -65,6 +65,10 @@ dashscope:
 # Pexels 图片搜索配置
 pexels:
   api-key: <your-api-key>
+# You.com 联网搜索配置（获取 API 密钥: https://ydc-index.io/docs）
+youcom:
+  api-key: <your-api-key>
+  endpoint: https://ydc-index.io/v1/search
 # 生产环境关闭日志
 mybatis-flex:
   configuration:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -89,6 +89,10 @@ cos:
 # Pexels 图片搜索配置
 pexels:
   api-key: <Your API Key>
+# You.com 联网搜索配置（获取 API 密钥: https://ydc-index.io/docs）
+youcom:
+  api-key: <Your API Key>
+  endpoint: https://ydc-index.io/v1/search
 # 阿里云 DashScope 配置
 dashscope:
   api-key: <Your API Key>

--- a/yu-ai-code-mother-microservice/yu-ai-code-ai/src/main/java/com/yupi/yuaicodemother/ai/tools/YoucomSearchTool.java
+++ b/yu-ai-code-mother-microservice/yu-ai-code-ai/src/main/java/com/yupi/yuaicodemother/ai/tools/YoucomSearchTool.java
@@ -1,0 +1,115 @@
+package com.yupi.yuaicodemother.ai.tools;
+
+import cn.hutool.http.HttpRequest;
+import cn.hutool.http.HttpResponse;
+import cn.hutool.json.JSONObject;
+import dev.langchain4j.agent.tool.P;
+import dev.langchain4j.agent.tool.Tool;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * You.com 联网搜索工具
+ * 支持 AI 在生成应用时进行实时网页搜索，获取技术文档和最新资料
+ */
+@Slf4j
+@Component
+public class YoucomSearchTool extends BaseTool {
+
+    @Value("${youcom.api-key:}")
+    private String apiKey;
+
+    @Value("${youcom.endpoint:https://ydc-index.io/v1/search}")
+    private String endpoint;
+
+    @Tool("通过联网搜索获取与问题相关的最新信息")
+    public String search(@P("搜索关键词") String query) {
+        if (query == null || query.isBlank()) {
+            return "搜索关键词不能为空";
+        }
+
+        if (apiKey == null || apiKey.isBlank()) {
+            return "You.com Search API 未配置 YOUCOM_API_KEY，请在配置文件中设置 youcom.api-key";
+        }
+
+        JSONObject payload = new JSONObject();
+        payload.set("query", query);
+        payload.set("count", 10);
+
+        try (HttpResponse response = HttpRequest.post(endpoint)
+                .header("Accept", "application/json")
+                .header("X-API-Key", apiKey)
+                .body(payload.toString())
+                .timeout(30000)
+                .execute()) {
+            int status = response.getStatus();
+            if (status == 429) {
+                return "You.com Search 请求频率超限 (429)";
+            }
+            if (status == 401) {
+                return "You.com API Key 无效或已过期";
+            }
+            if (status == 403) {
+                return "You.com API Key 权限不足";
+            }
+            if (status != 200) {
+                return "You.com Search 请求失败 (Status " + status + ")";
+            }
+
+            return parseSearchResults(response.body());
+        } catch (Exception e) {
+            log.error("You.com Search 调用失败: {}", e.getMessage(), e);
+            return "You.com Search 请求失败: " + e.getMessage();
+        }
+    }
+
+    private String parseSearchResults(String jsonBody) {
+        try {
+            JSONObject result = new JSONObject(jsonBody);
+            List<?> webResults = result.getJSONArray("results");
+            if (webResults == null || webResults.isEmpty()) {
+                return "未找到相关结果";
+            }
+
+            List<String> lines = new ArrayList<>();
+            int count = Math.min(webResults.size(), 10);
+            for (int i = 0; i < count; i++) {
+                JSONObject item = (JSONObject) webResults.get(i);
+                String title = item.getStr("title");
+                if (title == null) {
+                    title = "结果 " + (i + 1);
+                }
+                String url = item.getStr("url");
+                cn.hutool.json.JSONArray snippets = item.getJSONArray("snippets");
+                String snippet = (snippets != null && !snippets.isEmpty())
+                        ? snippets.getStr(0)
+                        : item.getStr("description", "");
+                lines.add(String.format("[%d] %s\n   网址: %s\n   摘要: %s", i + 1, title, url, snippet));
+            }
+            return String.join("\n\n", lines);
+        } catch (Exception e) {
+            log.error("解析 You.com 搜索结果失败: {}", e.getMessage(), e);
+            return "解析搜索结果失败: " + e.getMessage();
+        }
+    }
+
+    @Override
+    public String getToolName() {
+        return "youcomSearch";
+    }
+
+    @Override
+    public String getDisplayName() {
+        return "联网搜索";
+    }
+
+    @Override
+    public String generateToolExecutedResult(JSONObject arguments) {
+        String query = arguments.getStr("query");
+        return String.format("[工具调用] %s 搜索关键词: %s", getDisplayName(), query);
+    }
+}

--- a/yu-ai-code-mother-microservice/yu-ai-code-ai/src/test/java/com/yupi/yuaicodemother/ai/tools/YoucomSearchToolTest.java
+++ b/yu-ai-code-mother-microservice/yu-ai-code-ai/src/test/java/com/yupi/yuaicodemother/ai/tools/YoucomSearchToolTest.java
@@ -1,0 +1,50 @@
+package com.yupi.yuaicodemother.ai.tools;
+
+import jakarta.annotation.Resource;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * YoucomSearchTool 集成测试
+ * 需要配置 youcom.api-key 才能正常运行（可设置为空字符串测试错误提示）
+ */
+@SpringBootTest
+class YoucomSearchToolTest {
+
+    @Resource
+    private YoucomSearchTool youcomSearchTool;
+
+    @Test
+    void testSearchWithConfiguredApiKey() {
+        String result = youcomSearchTool.search("人工智能最新进展");
+        assertNotNull(result);
+        // 有 API Key 时应返回搜索结果或错误信息（不会是配置缺失提示）
+        assertFalse(result.contains("未配置 YOUCOM_API_KEY"),
+                "API Key 已配置但返回了未配置错误");
+        System.out.println("搜索结果: " + result);
+    }
+
+    @Test
+    void testSearchEmptyQuery() {
+        String result = youcomSearchTool.search("");
+        assertEquals("搜索关键词不能为空", result);
+    }
+
+    @Test
+    void testSearchBlankQuery() {
+        String result = youcomSearchTool.search("   ");
+        assertEquals("搜索关键词不能为空", result);
+    }
+
+    @Test
+    void testToolName() {
+        assertEquals("youcomSearch", youcomSearchTool.getToolName());
+    }
+
+    @Test
+    void testDisplayName() {
+        assertEquals("联网搜索", youcomSearchTool.getDisplayName());
+    }
+}


### PR DESCRIPTION
## 概要

为 AI 代码生成平台添加 You.com 联网搜索工具，集成到 VUE_PROJECT 代码生成流程中。

## 改动内容

- **YoucomSearchTool**：新增搜索工具类，继承 `BaseTool`，使用 `hutool` HTTP 客户端调用 You.com Search API（`POST https://ydc-index.io/v1/search`），通过 `ToolManager` 自动发现注册，对 AI 生成 Vue 项目时可用
- **YoucomSearchToolTest**：集成测试，覆盖空查询校验、API Key 配置检查、工具元数据（名称/显示名）验证
- **application.yml / application-prod-sample.yml**：新增 `youcom.api-key` 和 `youcom.endpoint` 配置项

## 影响范围

仅影响 VUE_PROJECT 生成类型（HTML 和 MULTI_FILE 模式不受影响），不改变现有工具调用逻辑